### PR TITLE
Applied getWinnerText(result) to getGameOverContent on snake.ts

### DIFF
--- a/src/2048.ts
+++ b/src/2048.ts
@@ -50,7 +50,7 @@ export default class TwentyFortyEightGame extends GameBase {
                 .setTitle('2048')
                 .setAuthor('Made By: TurkeyDev', 'https://site.theturkey.dev/images/turkey_avatar.png', 'https://www.youtube.com/watch?v=zHyKnlUWnp8')
                 .setImage(`https://api.theturkey.dev/discordgames/gen2048?gb=${this.gameBoard.join(',')}`)
-                .setDescription(`GAME OVER!\nScore: ${this.score}`)
+                .setDescription(`GAME OVER!\n${this.getWinnerText(result)}\nScore: ${this.score}`)
                 .setTimestamp()],
             components: []
         };

--- a/src/flood.ts
+++ b/src/flood.ts
@@ -63,7 +63,7 @@ export default class FloodGame extends GameBase {
                 .setColor('#08b9bf')
                 .setTitle('Flood')
                 .setAuthor('Made By: TurkeyDev', 'https://site.theturkey.dev/images/turkey_avatar.png', 'https://www.youtube.com/watch?v=BCKoXy94PM4')
-                .setDescription(`GAME OVER!\n${turnResp}`)
+                .setDescription(`GAME OVER!\n${this.getWinnerText(result)}\n${turnResp}`)
                 .setTimestamp()],
             components: []
         };

--- a/src/snake.ts
+++ b/src/snake.ts
@@ -102,7 +102,7 @@ export default class SnakeGame extends GameBase {
                 .setColor('#03ad03')
                 .setTitle('Snake Game')
                 .setAuthor('Made By: TurkeyDev', 'https://site.theturkey.dev/images/turkey_avatar.png', 'https://www.youtube.com/watch?v=tk5c0t72Up4')
-                .setDescription(`**GAME OVER!**\nScore: ${this.score}\n\n${this.getGameBoard()}`)
+                .setDescription(`**GAME OVER!**\n${this.getWinnerText(result)}\nScore: ${this.score}\n\n${this.getGameBoard()}`)
                 .setTimestamp()],
             components: []
         };


### PR DESCRIPTION
Snake currently does not display the playername, nor whether the game was won, lost, force-ended, etc.. like the other minigames do. 

![](https://i.gyazo.com/b2f7dbba219049d6dd469f7e7ee74dbe.png)

Might need to double check the accessibility on `this.getWinnerText()` as I had wrote this patch on github.dev which has fairly poor intellisense and i wasnt sure if the method was even usable at the time, although i dont see why it wouldnt be as every other minigame could call it.